### PR TITLE
Fix for #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# i18n compiled
+*.mo
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# Products.CompositePack
+CompositePack is a product that allows a user to build composite pages by manually aggregating Archetype-based content from his site. It features a WYWIWYG user interface that provides drag-n-drop positioning of content on the page.
+
+This is a very old product for Plone, and has been depricated in favor of plone.app.mosaic https://github.com/plone/plone.app.mosaic

--- a/src/Products/CompositePack/exportimport/compositetool.py
+++ b/src/Products/CompositePack/exportimport/compositetool.py
@@ -41,7 +41,11 @@ class CompositeToolXMLAdapter(XMLAdapterBase, ObjectManagerHelpers):
         """
         Import the object from the DOM node.
         """
-        if self.environ.shouldPurge():
+        import pdb; pdb.set_trace()
+        purge = self.environ.shouldPurge()
+        if node.getAttribute('purge'):
+            purge = self._convertToBoolean(node.getAttribute('purge'))
+        if purge:
             self._purgeObjects()
 
         self._initObjects(node)

--- a/src/Products/CompositePack/exportimport/compositetool.py
+++ b/src/Products/CompositePack/exportimport/compositetool.py
@@ -41,7 +41,6 @@ class CompositeToolXMLAdapter(XMLAdapterBase, ObjectManagerHelpers):
         """
         Import the object from the DOM node.
         """
-        import pdb; pdb.set_trace()
         purge = self.environ.shouldPurge()
         if node.getAttribute('purge'):
             purge = self._convertToBoolean(node.getAttribute('purge'))


### PR DESCRIPTION
Basically, we call the import process 'bugged' because it does not support the 'purge' attribute.

Now, we add that to the import process.

The top node:  <object> of the GSP .xml file should have the 'purge' attribute set to true or false.

One might consider adding purge to each of composites, composables or viewlets, but the purge method will have to be rewritten to support that.